### PR TITLE
molly: fix executing of method close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Executing `close` method in a `Client` instance (#2).
+
 [Unreleased]: https://github.com/ligurio/molly/compare/0.1.0...HEAD
 
 ## 0.1.0

--- a/molly/client.lua
+++ b/molly/client.lua
@@ -58,12 +58,14 @@ local function invoke(thread_id, opts)
     log.debug('Opening connection by thread %d to DB (%s)', thread_id, addr)
     local ok, err = pcall(client.open, client, addr)
     if not ok then
+        log.info('ERROR: %s', err)
         return false, err
     end
 
     log.debug('Setting up DB (%s) by thread %d', addr, thread_id)
     ok, err = pcall(client.setup, client)
     if not ok then
+        log.info('ERROR: %s', err)
         return false, err
     end
 
@@ -92,12 +94,14 @@ local function invoke(thread_id, opts)
     log.debug('Tearing down DB (%s) by thread %d', addr, thread_id)
     ok, err = pcall(client.teardown, client)
     if not ok then
+        log.info('ERROR: %s', err)
         return false, err
     end
 
     log.debug('Closing connection to DB (%s) by thread %d', addr, thread_id)
     ok, err = pcall(client.close, client)
     if not ok then
+        log.info('ERROR: %s', err)
         return false, err
     end
 

--- a/test/examples/sqlite-list-append.lua
+++ b/test/examples/sqlite-list-append.lua
@@ -87,14 +87,17 @@ end
 sqlite_list_append.teardown = function(self)
     --self.insert_stmt:finalize()
     --self.select_stmt:finalize()
-    local changes = self.db:total_changes()
-    --assert(changes == 500, string.format('Number of operations is wrong (%d != 500)', changes))
-    print('Total changes in SQLite DB:', changes)
     return true
 end
 
 sqlite_list_append.close = function(self)
-    self.db:close()
+    -- Close database. All SQL statements prepared using
+    -- db:prepare() should have been finalized before this
+    -- function is called. The function returns sqlite3.OK on
+    -- success or else a numerical error code.
+    if self.db:isopen() then
+        assert(self.db:close() == sqlite3.OK)
+    end
     return true
 end
 

--- a/test/examples/sqlite-rw-register.lua
+++ b/test/examples/sqlite-rw-register.lua
@@ -104,14 +104,17 @@ end
 sqlite_rw_register.teardown = function(self)
     --self.insert_stmt:finalize()
     --self.select_stmt:finalize()
-    local changes = self.db:total_changes()
-    assert(changes == 500, string.format('Number of operations is wrong (%d != 500)', changes))
-    print('Total changes in SQLite DB:', changes)
     return true
 end
 
 sqlite_rw_register.close = function(self)
-    self.db:close()
+    -- Close database. All SQL statements prepared using
+    -- db:prepare() should have been finalized before this
+    -- function is called. The function returns sqlite3.OK on
+    -- success or else a numerical error code.
+    if self.db:isopen() then
+        assert(self.db:close() == sqlite3.OK)
+    end
     return true
 end
 


### PR DESCRIPTION
- Fix executing of a `close` method due to early return
- Add logging to client methods
- Fix errors in test examples

Fix #2