### PR TITLE
test: use precompiled statements in examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Using of SQL prepared statements in test examples.
+
 ### Removed
 
 ### Fixed

--- a/test/examples/sqlite-list-append.lua
+++ b/test/examples/sqlite-list-append.lua
@@ -9,7 +9,7 @@ local os = require('os')
 print('SQLite version:', sqlite3.version())
 print('lsqlite3 library version:', sqlite3.lversion())
 
-local function insert(stmt, key, val) -- luacheck: no unused
+local function sqlite_insert(stmt, key, val)
     local ok = stmt:bind_values(key, val)
     if ok ~= sqlite3.OK then
         return false
@@ -23,7 +23,7 @@ local function insert(stmt, key, val) -- luacheck: no unused
     return true
 end
 
-local function select(stmt, key) -- luacheck: no unused
+local function sqlite_select(stmt, key)
     local values = {}
     for row in stmt:nrows() do
         if row.key == key then
@@ -45,13 +45,13 @@ sqlite_list_append.open = function(self)
     assert(sqlite3.OK == self.db:exec('PRAGMA synchronous = normal'))
     assert(sqlite3.OK == self.db:exec('PRAGMA mmap_size = 30000000000'))
     assert(sqlite3.OK == self.db:exec('PRAGMA page_size = 32768'))
-    --self.insert_stmt = assert(self.db:prepare('INSERT INTO list_append VALUES (?, ?)'))
-    --self.select_stmt = assert(self.db:prepare('SELECT key, val FROM list_append ORDER BY key'))
     return true
 end
 
 sqlite_list_append.setup = function(self)
     assert(sqlite3.OK == self.db:exec('CREATE TABLE IF NOT EXISTS list_append (key INT NOT NULL, val INT)'))
+    self.insert_stmt = assert(self.db:prepare('INSERT INTO list_append VALUES (?, ?)'))
+    self.select_stmt = assert(self.db:prepare('SELECT key, val FROM list_append ORDER BY key'))
     return true
 end
 
@@ -64,11 +64,9 @@ sqlite_list_append.invoke = function(self, op)
     local mop_key = mop[IDX_MOP_KEY]
     local type = 'ok'
     if mop[IDX_MOP_TYPE] == 'r' then
-        --mop[IDX_MOP_VAL] = select(self.select_stmt, mop_key)
-        mop[IDX_MOP_VAL] = self.db:exec('SELECT key, val FROM list_append ORDER BY key')
+        mop[IDX_MOP_VAL] = sqlite_select(self.select_stmt, mop_key)
     elseif mop[IDX_MOP_TYPE] == 'append' then
-        local ok = self.db:exec(string.format('INSERT INTO list_append VALUES (%s, %s)', mop_key, mop[IDX_MOP_VAL]))
-        --local ok = insert(self.insert_stmt, mop_key, mop[IDX_MOP_VAL])
+        local ok = sqlite_insert(self.insert_stmt, mop_key, mop[IDX_MOP_VAL])
         if ok == false then
             type = 'fail'
         end


### PR DESCRIPTION
Prepared statements improve performance by caching the execution plan for a query after the query optimizer has found the best plan.

If the query doesn't have a complicated plan (such as simple selects/inserts with no joins), then prepared statements won't give you a big improvement since the optimizer will quickly find the best plan.

SQLite helpers has been renamed in test examples.