### PR TITLE
molly: update an RW register generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow chaining `luafun` iterators with iterators defined in Molly and vice versa.
 - Using of SQL prepared statements in test examples.
 - Generated operation can be any callable Lua object.
+- RW-register generator emits every number only once.
 
 ### Removed
 


### PR DESCRIPTION
Elle's checker requires that operations on RW register must not write same numbers. The patch changes an RW-register operations generator in that way, every number emit only once. Also, a max number can be specified in `rw_register_gen()`, default value is equal to 1000.